### PR TITLE
Add a NeurIPS 2020 paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,3 +238,7 @@ We release [OpenKE](https://github.com/thunlp/openKE), an open source toolkit fo
 *Zhanqiu Zhang, Jianyu Cai, Yongdong Zhang, Jie Wang.* AAAI 2020. [paper](https://arxiv.org/pdf/1911.09419.pdf) [code](https://github.com/MIRALab-USTC/KGE-HAKE)
 	> This paper proposes a novel knowledge graph embedding model—namely, Hierarchy-Aware Knowledge Graph Embedding (HAKE). HAKE maps entities into the polar coordinate system to model semantic hierarchies, which are common in
 real-world applications. HAKE is inspired by the fact that concentric circles in the polar coordinate system can naturally reflect the hierarchy. 
+
+1. **Learning to Extrapolate Knowledge: Transductive Few-shot Out-of-Graph Link Prediction.**
+*Jinheon Baek, Dong Bok Lee, Sung Ju Hwang.* NeurIPS 2020. [paper](https://arxiv.org/pdf/2006.06648.pdf) [code](https://github.com/JinheonBaek/GEN)
+	> This paper tackles a realistic problem setting of few-shot out-of-graph link prediction, aiming to perform link prediction not only between seen and unseen entities but also among unseen entities. To tackle this problem, they propose a novel meta-learning framework, Graph Extrapolation Network (GEN), which meta-learns the node embeddings for unseen entities, to obtain low error on link prediction for both seen-to-unseen and unseen-to-unseen cases.

--- a/krl.bib
+++ b/krl.bib
@@ -315,3 +315,10 @@ year = {2018}
   year={2018},
   organization={Springer}
 }
+
+@article{baek2020KG,
+  title={Learning to Extrapolate Knowledge: Transductive Few-shot Out-of-Graph Link Prediction},
+  author={Jinheon Baek and Dong Bok Lee and Sung Ju Hwang},
+  journal={arXiv preprint arXiv:2006.06648},
+  year={2020}
+}


### PR DESCRIPTION
Please add a NeurIPS 2020 paper: Learning to Extrapolate Knowledge: Transductive Few-shot Out-of-Graph Link Prediction.

Thanks for maintaining this repository.

Sincerely,
Jinheon Baek